### PR TITLE
Efficient permutation

### DIFF
--- a/bsseval/metrics.py
+++ b/bsseval/metrics.py
@@ -242,9 +242,7 @@ def bss_eval(reference_sources, estimated_sources,
             (G, sf, C) = compute_GsfC(win)
             Cj = compute_Cj(win)
 
-        # loop over all permutations
-        done = np.zeros((nsrc, nsrc))
-
+        # loop over all pairs
         ref_slice = reference_sources[:, win]
         est_slice = estimated_sources[:, win]
         if (
@@ -252,24 +250,22 @@ def bss_eval(reference_sources, estimated_sources,
             not _any_source_silent(est_slice)
         ):
             for jtrue in range(nsrc):
-                for (k, jest) in enumerate(candidate_permutations[:, jtrue]):
+                for jest in range(nsrc):
                     # if we have a silent frame set results as np.nan
-                    if not done[jtrue, jest]:
-                            s_true, e_spat, e_interf, e_artif = \
-                                _bss_decomp_mtifilt(
-                                    reference_sources[:, win],
-                                    estimated_sources[jest, win],
-                                    jtrue, C[jest],
-                                    Cj[jtrue, jest, 0]
-                                )
-                            s_r[:, jtrue, jest, t] = _bss_crit(
-                                s_true,
-                                e_spat,
-                                e_interf,
-                                e_artif,
-                                bsseval_sources_version
-                            )
-                            done[jtrue, jest] = True
+                    s_true, e_spat, e_interf, e_artif = \
+                        _bss_decomp_mtifilt(
+                            reference_sources[:, win],
+                            estimated_sources[jest, win],
+                            jtrue, C[jest],
+                            Cj[jtrue, jest, 0]
+                        )
+                    s_r[:, jtrue, jest, t] = _bss_crit(
+                        s_true,
+                        e_spat,
+                        e_interf,
+                        e_artif,
+                        bsseval_sources_version
+                    )
         else:
             a = np.empty((4, nsrc, nsrc))
             a[:] = np.nan

--- a/bsseval/utils.py
+++ b/bsseval/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.optimize import linear_sum_assignment
 
 
 def pad_or_truncate(
@@ -40,3 +41,38 @@ def pad_or_truncate(
             )
 
     return audio_reference, audio_estimates
+
+
+def linear_sum_assignment_with_inf(cost_matrix):
+    '''
+    Solves the permutation problem efficiently via the linear sum
+    assignment problem.
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linear_sum_assignment.html
+
+    This implementation was proposed by @louisabraham in
+    https://github.com/scipy/scipy/issues/6900
+    to handle infinite entries in the cost matrix.
+    '''
+    cost_matrix = np.asarray(cost_matrix)
+    min_inf = np.isneginf(cost_matrix).any()
+    max_inf = np.isposinf(cost_matrix).any()
+    if min_inf and max_inf:
+        raise ValueError("matrix contains both inf and -inf")
+
+    if min_inf or max_inf:
+        cost_matrix = cost_matrix.copy()
+        values = cost_matrix[~np.isinf(cost_matrix)]
+        m = values.min()
+        M = values.max()
+        n = min(cost_matrix.shape)
+        # strictly positive constant even when added
+        # to elements of the cost matrix
+        positive = n * (M - m + np.abs(M) + np.abs(m) + 1)
+        if max_inf:
+            place_holder = (M + (n - 1) * (M - m)) + positive
+        if min_inf:
+            place_holder = (m + (n - 1) * (m - M)) - positive
+
+        cost_matrix[np.isinf(cost_matrix)] = place_holder
+
+    return linear_sum_assignment(cost_matrix)


### PR DESCRIPTION
Hi, I have tried modifying the code to use an efficient algorithm to solve for the permutation, as described in Issue #5. I removed all references and loops over the exhaustive `candidate_permutations`. Instead, we can use double for loops on all pairs to fill the metrics array. At the end, the permutation is solved for every frame. I have also simplified a little bit the code so that the single frame case is handled in the same way. For silent frames, the metrics are set to nan as previously and the permutation output is fixed to `np.arange(nsrc)`.

I have only run simple test cases and the output seems to be the same as that of `mir_eval`. I would love to run the tests but I couldn't find the instructions to download the test dataset. Note that the modification is very similar to what I proposed in craffel/mir_eval#318